### PR TITLE
mysql docker 로컬 테스트 세팅

### DIFF
--- a/docker/db/mysql/init/init.sql
+++ b/docker/db/mysql/init/init.sql
@@ -1,0 +1,6 @@
+CREATE USER 'master'@'%' IDENTIFIED BY 'master';
+GRANT ALL PRIVILEGES ON *.* TO 'master'@'%';
+FLUSH PRIVILEGES;
+
+--TODO: table setting
+drop table IF EXISTS test;

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  db:
+    image: mysql:8.0.28
+    container_name: 8potatoes-mysql-container
+    environment:
+      MYSQL_USER: 'master'
+      MYSQL_ROOT_PASSWORD: 'master'
+      MYSQL_DATABASE: restarea
+      TZ: 'Asia/Seoul'
+    ports:
+      - "3307:3306"
+    volumes:
+      - ./db/mysql/init:/docker-entrypoint-initdb.d


### PR DESCRIPTION
## ✨ Summary

-   로컬 테스트 & 서버 띄우기 전까지 개발할 수 있도록 mysql docker 환경을 추가했습니다.

## ✍🏻 Describe changes

-  우선 mysql 8.0으로 했는데 변경 필요하시면 의견 부탁드려요!
-  init.sql에 테이블 추가하면서 개발 진행하면 좋을 것 같습니다!