### PR TITLE
[#3] 휴게소 메뉴 정보 Open API 조회 및 Upsert API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,11 +22,16 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
-	implementation("io.r2dbc:r2dbc-mysql")
+	implementation("dev.miku:r2dbc-mysql:0.8.2.RELEASE")
+	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-	runtimeOnly("mysql:mysql-connector-java")
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
+	runtimeOnly("mysql:mysql-connector-java:8.0.28")
+	runtimeOnly("io.r2dbc:r2dbc-pool")
+	runtimeOnly("io.r2dbc:r2dbc-spi")
+	runtimeOnly("io.netty:netty-resolver-dns-native-macos:4.1.80.Final:osx-aarch_64")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("io.projectreactor:reactor-test")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
-	implementation("dev.miku:r2dbc-mysql:0.8.2.RELEASE")
+	implementation("io.asyncer:r2dbc-mysql:1.1.0")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/docker/db/mysql/init/init.sql
+++ b/docker/db/mysql/init/init.sql
@@ -8,12 +8,14 @@ USE reststop;
 
 CREATE TABLE menu (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    food_seq VARCHAR(255) NOT NULL UNIQUE,
     name VARCHAR(255) NOT NULL,
-    food_seq VARCHAR(255),
     price INT,
     description TEXT,
     is_recommended BOOLEAN,
     is_premium BOOLEAN,
     is_best_food BOOLEAN,
-    reststop_id INT
+    reststop_id INT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );

--- a/docker/db/mysql/init/init.sql
+++ b/docker/db/mysql/init/init.sql
@@ -1,4 +1,4 @@
-CREATE USER 'master'@'%' IDENTIFIED BY 'master';
+CREATE USER IF NOT EXISTS 'master'@'%' IDENTIFIED BY 'master';
 GRANT ALL PRIVILEGES ON *.* TO 'master'@'%';
 FLUSH PRIVILEGES;
 

--- a/docker/db/mysql/init/init.sql
+++ b/docker/db/mysql/init/init.sql
@@ -2,5 +2,18 @@ CREATE USER 'master'@'%' IDENTIFIED BY 'master';
 GRANT ALL PRIVILEGES ON *.* TO 'master'@'%';
 FLUSH PRIVILEGES;
 
---TODO: table setting
-drop table IF EXISTS test;
+CREATE DATABASE IF NOT EXISTS reststop;
+
+USE reststop;
+
+CREATE TABLE menu (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    food_seq VARCHAR(255),
+    price INT,
+    description TEXT,
+    is_recommended BOOLEAN,
+    is_premium BOOLEAN,
+    is_best_food BOOLEAN,
+    reststop_id INT
+);

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,14 +1,18 @@
-version: '3'
 services:
   db:
     image: mysql:8.0.28
+    platform: linux/amd64
     container_name: 8potatoes-mysql-container
     environment:
-      MYSQL_USER: 'master'
       MYSQL_ROOT_PASSWORD: 'master'
-      MYSQL_DATABASE: restarea
+      MYSQL_DATABASE: reststop
+      MYSQL_USER: 'master'
+      MYSQL_PASSWORD: 'master'
       TZ: 'Asia/Seoul'
     ports:
       - "3307:3306"
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
     volumes:
       - ./db/mysql/init:/docker-entrypoint-initdb.d

--- a/http/openapi.http
+++ b/http/openapi.http
@@ -1,0 +1,2 @@
+### 휴게소 메뉴 데이터 Upsert(w/OpenAPI)
+POST http://localhost:8099/api/reststop/foods

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "nexters"
+rootProject.name = "eightpotatoes"

--- a/src/main/kotlin/com/eightpotatoes/nexters/config/R2dbcConfig.kt
+++ b/src/main/kotlin/com/eightpotatoes/nexters/config/R2dbcConfig.kt
@@ -1,0 +1,8 @@
+package com.eightpotatoes.nexters.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.r2dbc.config.EnableR2dbcAuditing
+
+@Configuration
+@EnableR2dbcAuditing
+class R2dbcConfig

--- a/src/main/kotlin/com/eightpotatoes/nexters/controller/ReststopFoodController.kt
+++ b/src/main/kotlin/com/eightpotatoes/nexters/controller/ReststopFoodController.kt
@@ -1,0 +1,15 @@
+package com.eightpotatoes.nexters.controller
+
+import com.eightpotatoes.nexters.service.ReststopFoodService
+import kotlinx.coroutines.coroutineScope
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ReststopFoodController(private val reststopFoodService: ReststopFoodService) {
+
+    @PostMapping("/api/reststop/foods")
+    suspend fun upsertReststopFoods() = coroutineScope {
+        reststopFoodService.callAndUpsertAllFoodPages()
+    }
+}

--- a/src/main/kotlin/com/eightpotatoes/nexters/entity/Menu.kt
+++ b/src/main/kotlin/com/eightpotatoes/nexters/entity/Menu.kt
@@ -1,7 +1,10 @@
 package com.eightpotatoes.nexters.entity
 
+import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.relational.core.mapping.Table
+import java.time.LocalDateTime
 
 @Table("Menu")
 data class Menu(
@@ -14,4 +17,8 @@ data class Menu(
     val isPremium: Boolean,
     val isBestFood: Boolean,
     val reststopId: Int,
+    @CreatedDate
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    val updatedAt: LocalDateTime? = null
 )

--- a/src/main/kotlin/com/eightpotatoes/nexters/entity/Menu.kt
+++ b/src/main/kotlin/com/eightpotatoes/nexters/entity/Menu.kt
@@ -6,8 +6,10 @@ import org.springframework.data.relational.core.mapping.Table
 @Table("Menu")
 data class Menu(
     @Id val id: Int,
+    val foodSeq: String,
     val name: String,
     val price: Int,
+    val description: String?,
     val isRecommended: Boolean,
     val isPremium: Boolean,
     val isBestFood: Boolean,

--- a/src/main/kotlin/com/eightpotatoes/nexters/model/ReststopFood.kt
+++ b/src/main/kotlin/com/eightpotatoes/nexters/model/ReststopFood.kt
@@ -1,0 +1,42 @@
+package com.eightpotatoes.nexters.model
+
+import com.eightpotatoes.nexters.entity.Menu
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ReststopFood(
+    val stdRestCd: String,       // 휴게소/주유소코드
+    val routeCd: String,         // 노선코드
+    val svarAddr: String,        // 휴게소주소
+    val restCd: String,          // 휴게소코드
+    val routeNm: String,         // 노선명
+    val stdRestNm: String,       // 휴게소/주유소명
+    val lsttmAltrUser: String,   // 최종수정사용자
+    val lsttmAltrDttm: String,   // 최종수정일시
+    val seq: String,             // 음식 시퀀스
+    val foodNm: String,          // 음식 이름
+    val foodCost: String,        // 음식 가격
+    val etc: String?,            // 상세내역
+    val recommendyn: String,     // 추천메뉴 구분
+    val seasonMenu: String,      // 계절메뉴 구분 (4:사계절, S:여름, W:겨울)
+    val bestfoodyn: String,      // 베스트푸드 구분
+    val premiumyn: String,       // 프리미엄메뉴 구분
+    val app: String,             // 하이쉼마루 앱 표출 여부
+    val foodMaterial: String?,   // 요리재료
+    val lastId: String,          // 최초등록자
+    val lastDtime: String        // 최초등록일시
+) {
+    fun toMenu(): Menu {
+        return Menu(
+            id = 0,
+            foodSeq = seq,
+            name = foodNm,
+            price = foodCost.toIntOrNull() ?: 0,
+            description = etc,
+            isRecommended = recommendyn.equals("Y", ignoreCase = true),
+            isPremium = premiumyn.equals("Y", ignoreCase = true),
+            isBestFood = bestfoodyn.equals("Y", ignoreCase = true),
+            reststopId = stdRestCd.toIntOrNull() ?: 0
+        )
+    }
+}

--- a/src/main/kotlin/com/eightpotatoes/nexters/model/ReststopFoodResponse.kt
+++ b/src/main/kotlin/com/eightpotatoes/nexters/model/ReststopFoodResponse.kt
@@ -1,0 +1,9 @@
+package com.eightpotatoes.nexters.model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ReststopFoodResponse(
+    val count: Int,
+    val list: List<ReststopFood>,
+)

--- a/src/main/kotlin/com/eightpotatoes/nexters/repository/CustomMenuRepository.kt
+++ b/src/main/kotlin/com/eightpotatoes/nexters/repository/CustomMenuRepository.kt
@@ -1,0 +1,7 @@
+package com.eightpotatoes.nexters.repository
+
+import com.eightpotatoes.nexters.entity.Menu
+
+interface CustomMenuRepository {
+    suspend fun upsertMenu(menu: Menu): Menu
+}

--- a/src/main/kotlin/com/eightpotatoes/nexters/repository/CustomMenuRepositoryImpl.kt
+++ b/src/main/kotlin/com/eightpotatoes/nexters/repository/CustomMenuRepositoryImpl.kt
@@ -1,0 +1,46 @@
+package com.eightpotatoes.nexters.repository
+
+import com.eightpotatoes.nexters.entity.Menu
+import io.r2dbc.spi.Parameters
+import kotlinx.coroutines.reactor.awaitSingle
+import org.springframework.r2dbc.core.DatabaseClient
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+@Repository
+class CustomMenuRepositoryImpl(
+    private val databaseClient: DatabaseClient
+) : CustomMenuRepository {
+    override suspend fun upsertMenu(menu: Menu): Menu {
+        val query = """
+            INSERT INTO menu (name, food_seq, price, description, is_recommended, is_premium, is_best_food, reststop_id, created_at, updated_at)
+            VALUES (:name, :foodSeq, :price, :description, :isRecommended, :isPremium, :isBestFood, :reststopId, :createdAt, :updatedAt)
+            ON DUPLICATE KEY UPDATE
+                name = VALUES(name),
+                price = VALUES(price),
+                description = VALUES(description),
+                is_recommended = VALUES(is_recommended),
+                is_premium = VALUES(is_premium),
+                is_best_food = VALUES(is_best_food),
+                reststop_id = VALUES(reststop_id),
+                updated_at = VALUES(updated_at)
+        """.trimIndent()
+
+        databaseClient.sql(query)
+            .bind("name", menu.name)
+            .bind("foodSeq", menu.foodSeq)
+            .bind("price", menu.price)
+            .bind("description", menu.description ?: Parameters.`in`(String::class.java))
+            .bind("isRecommended", menu.isRecommended)
+            .bind("isPremium", menu.isPremium)
+            .bind("isBestFood", menu.isBestFood)
+            .bind("reststopId", menu.reststopId)
+            .bind("createdAt", menu.createdAt ?: LocalDateTime.now())
+            .bind("updatedAt", LocalDateTime.now())
+            .fetch()
+            .rowsUpdated()
+            .awaitSingle()
+
+        return menu
+    }
+}

--- a/src/main/kotlin/com/eightpotatoes/nexters/repository/MenuRepository.kt
+++ b/src/main/kotlin/com/eightpotatoes/nexters/repository/MenuRepository.kt
@@ -4,6 +4,4 @@ import com.eightpotatoes.nexters.entity.Menu
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
 
-interface MenuRepository : ReactiveCrudRepository<Menu, Int> {
-    fun findByReststopId(reststopId: Int): Flux<Menu>
-}
+interface MenuRepository : ReactiveCrudRepository<Menu, Long>, CustomMenuRepository

--- a/src/main/kotlin/com/eightpotatoes/nexters/service/MenuService.kt
+++ b/src/main/kotlin/com/eightpotatoes/nexters/service/MenuService.kt
@@ -1,0 +1,14 @@
+package com.eightpotatoes.nexters.service
+
+import com.eightpotatoes.nexters.entity.Menu
+import com.eightpotatoes.nexters.repository.MenuRepository
+import org.springframework.stereotype.Service
+
+@Service
+class MenuService(
+    private val menuRepository: MenuRepository
+) {
+    suspend fun upsertMenu(menu: Menu): Menu {
+        return menuRepository.upsertMenu(menu)
+    }
+}

--- a/src/main/kotlin/com/eightpotatoes/nexters/service/ReststopFoodService.kt
+++ b/src/main/kotlin/com/eightpotatoes/nexters/service/ReststopFoodService.kt
@@ -1,0 +1,49 @@
+package com.eightpotatoes.nexters.service
+
+import com.eightpotatoes.nexters.model.ReststopFoodResponse
+import com.eightpotatoes.nexters.repository.MenuRepository
+import kotlinx.coroutines.reactive.awaitSingle
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+
+@Service
+class ReststopFoodService(
+    @Value("\${api.base.url}") private val baseUrl: String,
+    @Value("\${api.key}") private val apiKey: String,
+    private val menuRepository: MenuRepository,
+) {
+    private val webClient: WebClient = WebClient.builder()
+        .baseUrl(baseUrl)
+        .defaultHeader("User-Agent", "Mozilla/5.0")
+        .build()
+
+    suspend fun callAndUpsertAllFoodPages(totalPages: Int = 54): List<ReststopFoodResponse> {
+        val responses = (1..totalPages).map { page ->
+            val response = callOpenAPIReststopFood(page)
+            response.list?.let { items ->
+                items.map { item -> item.toMenu() }
+                    .forEach { menu ->
+                        menuRepository.save(menu).awaitSingle()
+                    }
+            }
+            response
+        }
+        return responses
+    }
+
+    private suspend fun callOpenAPIReststopFood(pageNo: Int): ReststopFoodResponse {
+        return webClient.get()
+            .uri { builder ->
+                builder.path("/openapi/restinfo/restBestfoodList")
+                    .queryParam("key", apiKey)
+                    .queryParam("type", "json")
+                    .queryParam("numOfRows", "99")
+                    .queryParam("pageNo", pageNo)
+                    .build()
+            }
+            .retrieve()
+            .bodyToMono(ReststopFoodResponse::class.java)
+            .awaitSingle()
+    }
+}

--- a/src/main/kotlin/com/eightpotatoes/nexters/service/ReststopFoodService.kt
+++ b/src/main/kotlin/com/eightpotatoes/nexters/service/ReststopFoodService.kt
@@ -1,7 +1,6 @@
 package com.eightpotatoes.nexters.service
 
 import com.eightpotatoes.nexters.model.ReststopFoodResponse
-import com.eightpotatoes.nexters.repository.MenuRepository
 import kotlinx.coroutines.reactive.awaitSingle
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -11,7 +10,7 @@ import org.springframework.web.reactive.function.client.WebClient
 class ReststopFoodService(
     @Value("\${api.base.url}") private val baseUrl: String,
     @Value("\${api.key}") private val apiKey: String,
-    private val menuRepository: MenuRepository,
+    private val menuService: MenuService,
 ) {
     private val webClient: WebClient = WebClient.builder()
         .baseUrl(baseUrl)
@@ -21,10 +20,10 @@ class ReststopFoodService(
     suspend fun callAndUpsertAllFoodPages(totalPages: Int = 54): List<ReststopFoodResponse> {
         val responses = (1..totalPages).map { page ->
             val response = callOpenAPIReststopFood(page)
-            response.list?.let { items ->
+            response.list.let { items ->
                 items.map { item -> item.toMenu() }
                     .forEach { menu ->
-                        menuRepository.save(menu).awaitSingle()
+                        menuService.upsertMenu(menu)
                     }
             }
             response

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,15 @@
+server:
+  port: 8099
 spring:
   r2dbc:
-    url: r2dbc:mysql://localhost:3306/eightpotatoes_db
-    username: ${{secrets.dbUserName}}"
-    password: ${{secrets.dbPassword}}"
+    url: r2dbc:mysql://localhost:3307/reststop?serverTimezone=Asia/Seoul
+    username: master
+    password: master
   jpa:
     hibernate:
       ddl-auto: update
     show-sql: true
+api:
+  base:
+    url: https://data.ex.co.kr
+  key: 3951846914


### PR DESCRIPTION
## ✨ Summary

- 휴게소 메뉴 정보를 Open API를 통해 조회하고, MySQL DB에 Upsert 합니다.

## ✍🏻 Describe changes

- 휴게소 메뉴 정보는 최대 99건씩 조회되기 때문에 99건씩 54번 호출했습니다.
- R2DBC에서 Upsert 구현이 좀 지저분하지만, 작성했습니다.
- docker-compose와 init.sql도 조금 수정했습니다.

## 📌 Issue number

#3 : OpenAPI 연동 및 휴게소 데이터 구성