### PR TITLE
[feature/add-convenient-facility-to-api] 휴게소 상세정보 조회 API에 편의시설 정보 추가

### DIFF
--- a/core/src/main/kotlin/com/eightpotatoes/nexters/core/repository/ConvenientFacilityRepository.kt
+++ b/core/src/main/kotlin/com/eightpotatoes/nexters/core/repository/ConvenientFacilityRepository.kt
@@ -3,4 +3,6 @@ package com.eightpotatoes.nexters.core.repository
 import com.eightpotatoes.nexters.core.entity.ConvenientFacility
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ConvenientFacilityRepository : JpaRepository<ConvenientFacility, Long>
+interface ConvenientFacilityRepository : JpaRepository<ConvenientFacility, Long> {
+    fun findByStandardCode(standardCode: String): List<ConvenientFacility>
+}

--- a/external-api/src/main/kotlin/com/eightpotatoes/nexters/api/external/mapper/ReststopMapper.kt
+++ b/external-api/src/main/kotlin/com/eightpotatoes/nexters/api/external/mapper/ReststopMapper.kt
@@ -29,7 +29,8 @@ object ReststopMapper {
     fun toReststopDetailResponse(
         reststop: Reststop,
         menus: List<Menu>,
-        brands: List<BrandData>
+        brands: List<BrandData>,
+        amenities: List<AmenityData>,
     ): ReststopDetailResponse {
         return ReststopDetailResponse(
             name = reststop.name,
@@ -54,7 +55,7 @@ object ReststopMapper {
             reststopData = ReststopAdditionalData(
                 restaurantOperatingTimes = createRestaurantOperatingTimes(), // TODO 식당 영업시간 데이터 추가 후 작업
                 brands = brands,
-                amenities = createAmenities(), // TODO 편의시설 데이터 추가 후 작업
+                amenities = amenities,
                 address = reststop.address ?: "",
                 phoneNumber = reststop.phoneNumber,
             ),
@@ -66,26 +67,12 @@ object ReststopMapper {
     private fun createRestaurantOperatingTimes(): List<RestaurantInfo> {
         return listOf(
             RestaurantInfo(
-                restaurantName = "식당가 (라면/우동)",
+                restaurantName = "[TEST] 식당가 (라면/우동)",
                 operatingTime = "09:00 ~ 21:00"
             ),
             RestaurantInfo(
-                restaurantName = "달콤커피 커피전문점",
+                restaurantName = "[TEST] 달콤커피 커피전문점",
                 operatingTime = "08:00 ~ 22:00"
-            )
-        )
-    }
-
-    // Dummy 편의시설 데이터 리스트 생성
-    private fun createAmenities(): List<AmenityData> {
-        return listOf(
-            AmenityData(
-                amenityName = "화장실",
-                amenityLogoUrl = "https://github.com/user-attachments/assets/0f2a2a5b-33a5-4d89-bacb-9a4f55b935de"
-            ),
-            AmenityData(
-                amenityName = "ATM",
-                amenityLogoUrl = "https://github.com/user-attachments/assets/0f2a2a5b-33a5-4d89-bacb-9a4f55b935de"
             )
         )
     }

--- a/external-api/src/main/kotlin/com/eightpotatoes/nexters/api/external/service/ReststopExternalService.kt
+++ b/external-api/src/main/kotlin/com/eightpotatoes/nexters/api/external/service/ReststopExternalService.kt
@@ -1,10 +1,7 @@
 package com.eightpotatoes.nexters.api.external.service
 
 import com.eightpotatoes.nexters.api.external.mapper.ReststopMapper
-import com.eightpotatoes.nexters.api.external.model.BrandData
-import com.eightpotatoes.nexters.api.external.model.ReststopDetailAtHighway
-import com.eightpotatoes.nexters.api.external.model.ReststopDetailResponse
-import com.eightpotatoes.nexters.api.external.model.ReststopsAtHighway
+import com.eightpotatoes.nexters.api.external.model.*
 import com.eightpotatoes.nexters.core.repository.*
 import com.eightpotatoes.nexters.core.util.ReststopUtils.isRestaurantOpen
 import org.springframework.stereotype.Service
@@ -16,6 +13,7 @@ class ReststopExternalService(
     private val reststopRepository: ReststopRepository,
     private val menuRepository: MenuRepository,
     private val brandRepository: BrandRepository,
+    private val convenientFacilityRepository: ConvenientFacilityRepository,
 ) {
     fun getReststopsAtHighways(
         roadNameList: List<String>,
@@ -52,6 +50,14 @@ class ReststopExternalService(
                 brandLogoUrl = it.thumbnailUrl
             )
         }
-        return Flux.just(ReststopMapper.toReststopDetailResponse(reststop, menus, brands))
+        // 편의시설 조회
+        val amenities = convenientFacilityRepository.findByStandardCode(reststopCode).map {
+            AmenityData(
+                amenityName = it.name,
+                amenityLogoUrl = "TEST", // TODO 편의시설 image 링크 추가
+            )
+        }
+
+        return Flux.just(ReststopMapper.toReststopDetailResponse(reststop, menus, brands, amenities))
     }
 }


### PR DESCRIPTION
## ✨ Summary

- 휴게소 상세정보 조회 API에 편의시설 정보 추가

## ✍🏻 Describe changes

- `AS-WAS` : 더미 데이터
- `TO-BE` : 편의시설 데이터 조회(이미지 URL 제외)

<img width="945" alt="image" src="https://github.com/user-attachments/assets/856a5fe0-f5a4-4d2b-ad52-bf79711b5d5d">


## 📌 Issue number

- #17