### PR TITLE
[feature/docker-mysql-utf8] docker mysql utf8 적용

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
+      - --skip-character-set-client-handshake
     volumes:
       - ./db/mysql/init:/docker-entrypoint-initdb.d
       - mysql_data:/var/lib/mysql


### PR DESCRIPTION
## ✨ Summary

- Docker mysql Query 실행 시 한글이 깨지는 문제가 있기 때문에 수정합니다.
- 임시로 Docker mysql server에 직접 접속해서 작업했습니다.

### 1) MySQL 컨테이너 접속

```bash
docker exec -it <컨테이너 명> /bin/bash
```

### 2) vim 설치 후 my.cnf 파일 수정

> 기본적으로 vim이 설치되어있지 않음

```bash
apt-get update
apt-get install vim
vim /etc/mysql/my.cnf
```

파일에 아래 UTF-8 설정 추가

```cnf
[client]
default-character-set=utf8

[mysql]
default-character-set=utf8

[mysqld]
collation-server = utf8_unicode_ci
init-connect='SET NAMES utf8'
character-set-server = utf8
```

## ✅ Result

<img width="1170" alt="image" src="https://github.com/user-attachments/assets/db74d60b-2a43-405d-98fb-b14c52d90bf7">

## 📌 Issue number

#35